### PR TITLE
Rename IsSameReferenceThan() to IsSameReferenceAs()

### DIFF
--- a/NFluent.35.Tests/DictionaryChecksTests.cs
+++ b/NFluent.35.Tests/DictionaryChecksTests.cs
@@ -47,7 +47,7 @@ namespace NFluent.Tests
 
             Check.That(SimpleDico).IsNotEqualTo(4);
 
-            Check.That(SimpleDico).IsSameReferenceThan(SimpleDico);
+            Check.That(SimpleDico).IsSameReferenceAs(SimpleDico);
         }
 
         [Test]

--- a/NFluent.35.Tests/ObjectRelatedTest.cs
+++ b/NFluent.35.Tests/ObjectRelatedTest.cs
@@ -23,24 +23,24 @@ namespace NFluent.Tests
     public class ObjectRelatedTest
     {
         [Test]
-        public void IsSameReferenceThanWorks()
+        public void IsSameReferenceAsWorks()
         {
             var test = new object();
-            Check.That(test).IsSameReferenceThan(test);
+            Check.That(test).IsSameReferenceAs(test);
         }
 
         [Test]
-        public void IsSameReferenceThanDoesNotLoseOriginalTypeForOtherCheck()
+        public void IsSameReferenceAsDoesNotLoseOriginalTypeForOtherCheck()
         {
             var numbers = new[] { 1, 4, 42 };
-            Check.That(numbers).IsSameReferenceThan(numbers).And.Contains(42);
+            Check.That(numbers).IsSameReferenceAs(numbers).And.Contains(42);
         }
 
         [Test]
         [ExpectedException(typeof(FluentCheckException), ExpectedMessage = "\nThe checked object must be the same instance than expected one.\nThe checked object:\n\t[System.Object]\nThe expected object: same instance than\n\t[System.Object]")]
         public void IsSameReferenceFailsProperly()
         {
-            Check.That(new object()).IsSameReferenceThan(new object());
+            Check.That(new object()).IsSameReferenceAs(new object());
         }
 
         [Test]
@@ -158,7 +158,7 @@ namespace NFluent.Tests
         {
             var test = new object();
             Check.That(test).Not.IsDistinctFrom(test);
-            Check.That(new object()).Not.IsSameReferenceThan(new object());
+            Check.That(new object()).Not.IsSameReferenceAs(new object());
         }
     }
 }

--- a/NFluent.35/Assertions/ObjectCheckExtensions.cs
+++ b/NFluent.35/Assertions/ObjectCheckExtensions.cs
@@ -12,6 +12,9 @@
 // //   limitations under the License.
 // // </copyright>
 // // --------------------------------------------------------------------------------------------------------------------
+
+using System.ComponentModel;
+
 namespace NFluent
 {
     using System;
@@ -259,7 +262,7 @@ namespace NFluent
         /// A check link.
         /// </returns>
         /// <exception cref="FluentCheckException">The actual value is not the same reference than the expected value.</exception>
-        public static ICheckLink<ICheck<T>> IsSameReferenceThan<T>(this ICheck<T> check, object expected)
+        public static ICheckLink<ICheck<T>> IsSameReferenceAs<T>(this ICheck<T> check, object expected)
         {
             var checker = ExtensibilityHelper.ExtractChecker(check);
             var negated = checker.Negated;
@@ -277,6 +280,25 @@ namespace NFluent
             }
 
             return checker.BuildChainingObject();
+        }
+
+        /// <summary>
+        /// Obsolete. Use <see cref="ObjectCheckExtensions.IsSameReferenceAs{T}"/> instead.
+        /// </summary>
+        /// <typeparam name="T">
+        /// Type of the checked value.
+        /// </typeparam>
+        /// <param name="check">The fluent check to be extended.</param>
+        /// <param name="expected">The expected object.</param>
+        /// <returns>
+        /// A check link.
+        /// </returns>
+        /// <exception cref="FluentCheckException">The actual value is not the same reference than the expected value.</exception>
+        [Obsolete]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static ICheckLink<ICheck<T>> IsSameReferenceThan<T>(this ICheck<T> check, object expected)
+        {
+            return IsSameReferenceAs(check, expected);
         }
 
         private static string SameReferenceImpl(object expected, object value, bool negated, out string comparison)

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -10,7 +10,7 @@ __Official site: [http://www.n-fluent.net/](http://www.n-fluent.net/)__
 - - - 
 
 __NFluent will make your tests__:
-+ __fluent to write__: with a __[super-duper-happy](https://github.com/NancyFx/Nancy/wiki/Introduction) auto-completion 'dot' experience__. Indeed, just type the Check.That( followed by one of your object and a dot, and your IDE will show you all the checks available for the type of the given object to verify. No more, no less (i.e. no auto completion flooding).
++ __fluent to write__: with a __[super-duper-happy](https://github.com/NancyFx/Nancy/wiki/Introduction) auto-completion 'dot' experience__. Indeed, just type the Check.That( followed by one of your objects and a dot, and your IDE will show you all the checks available for the type of the given object to verify. No more, no less (i.e. no auto completion flooding).
 + __fluent to read__: very close to plain English, making it easier for non-technical people to read test code.
 + __fluent to troubleshoot__: every failing check of the NFluent library throws an Exception with a crystal-clear message status to ease your TDD experience (see examples below). Thus, no need to set a breakpoint and to debug in order to be able to figure out what went wrong. 
 + __helpful to reverse engineer legacy code__: indeed, temporarily write an on-purpose failing assert on a legacy method, so you can understand it and leverage on the "ready-to-be-copied-and-paste-for-arrays-or-collections-initialization-purpose" NFluent assert failure messages.
@@ -34,7 +34,7 @@ As simple as possible
 
 With Nfluent check libraries:
 
-All you've got to remember is: `Check.That`, cause every check is then provided via a super-duper-auto-completion-dot-experience ;-)
+All you've got to remember is: `Check.That`, 'cause every check is then provided via a super-duper-auto-completion-dot-experience ;-)
 ------------------------------------------------------------------------------------------------------------------------
 
 
@@ -65,7 +65,7 @@ With NFluent, you can write simple checks like this:
     const Nationality FrenchNationality = Nationality.French;
     Check.ThatEnum(FrenchNationality).IsNotEqualTo(Nationality.Korean);
 
-    string motivationalSaying = "Failure is mother of success.";
+    string motivationalSaying = "Failure is the mother of success.";
     Check.That(motivationalSaying).IsNotInstanceOf<int>();
 
 ```
@@ -103,7 +103,7 @@ or like this:
 ``` 
 Why NFluent, and not another .NET fluent check framework?
 ----------------------------------------------------------------------------
-+ Because you think like us that writing a lambda expression within an check statement is not really a fluent experience (neither on a reading perspective).
++ Because you think like us that writing a lambda expression within a check statement is not really a fluent experience (for reading as well as writing).
 + Because NFluent is completely driven by the __[super-duper-happy-path](https://github.com/NancyFx/Nancy/wiki/Introduction)__ principle to fluent your TDD experience. For instance, we consider the 'dot' autocompletion experience as crucial. Thus, it should not be polluted by things not related to the current unit testing context (which occurs with extension methods on classical .NET types - intellisense flooding).
 + Because you think that those other check libraries have not chosen the proper vocabulary (`<subjectUnderTest>.Should().`... why don't they choose `Must` instead?!?). And thus, you'd rather rely on a stronger semantic for your checks (i.e. NFluent's `Check.That`).
 + Because you like *killing features* and extra bonus, such as the Properties() extension method for IEnumerable for instance (as showed within the usage sample above). 
@@ -130,13 +130,13 @@ Can't be more easy: NFluent is [available on nuget.org](http://nuget.org/package
 
 
 
-Uses cases
+Use cases
 ----------
 __[NFluent use cases are available here](./UseCases.md)__.
 
 Newsgroup
 ---------
-For any comment, remark or question on the library, please use the __[NFluent-Discuss google group](https://groups.google.com/forum/#!forum/nfluent-discuss)__.
+For any comment, remark or question about the library, please use the __[NFluent-Discuss google group](https://groups.google.com/forum/#!forum/nfluent-discuss)__.
 
 BackLog
 -------
@@ -145,8 +145,8 @@ Nfluent __backlog is now available as github issues__
 New feature to be added?
 ------------------------
 + If you want to join the project and contribute: __[check this out before](./CONTRIBUTING.md)__ before, but be our guest. 
-+ If you don't want to contribute on the library, but you need a feature not yet implemented, don't hesitate to request it on the __[NFluent-Discuss google group](https://groups.google.com/forum/#!forum/nfluent-discuss)__.
-__In any cases: you are welcome!__
++ If you don't want to contribute to the library, but you need a feature not yet implemented, don't hesitate to request it on the __[NFluent-Discuss google group](https://groups.google.com/forum/#!forum/nfluent-discuss)__.
+__In any case: you are welcome!__
 
 Other resources
 ---------------
@@ -171,4 +171,4 @@ Many thanks
 
 - - -
 
-[thomas@pierrain.net](mailto:thomas@pierrain.net) / April 2013
+[thomas@pierrain.net](mailto:thomas@pierrain.net) / April 2015


### PR DESCRIPTION
I've changed the name of the method to be grammatically correct. I also fixed several minor grammar inconsistencies in the ReadMe.
