### PR TITLE
Proposal: Add First and Single extension methods for collection checks

### DIFF
--- a/NFluent.35.Tests/EnumerableRelatedTests.cs
+++ b/NFluent.35.Tests/EnumerableRelatedTests.cs
@@ -12,10 +12,13 @@
 // //   limitations under the License.
 // // </copyright>
 // // --------------------------------------------------------------------------------------------------------------------
+
 namespace NFluent.Tests
 {
+    using System;
     using System.Collections;
     using System.Collections.Generic;
+    using System.Linq;
 
     using NUnit.Framework;
 
@@ -176,6 +179,166 @@ namespace NFluent.Tests
             var persons = new List<Person>();
 
             Check.That(persons).Not.IsEmpty();
+        }
+
+        #endregion
+
+        #region HasFirstElement
+
+        [Test]
+        public void HasFirstElementWorks()
+        {
+            var enumerable = new List<int> { 42, 43 };
+
+            Check.That(enumerable).HasFirstElement().That.IsEqualTo(42);
+        }
+
+        [Test]
+        [ExpectedException(typeof(FluentCheckException), ExpectedMessage = "\nThe checked enumerable is empty, where as it must have a first element.")]
+        public void HasFirstElementThrowsWhenCollectionIsEmpty()
+        {
+            Check.That(EmptyEnumerable).HasFirstElement();
+        }
+
+        [Test]
+        [ExpectedException(typeof(FluentCheckException), ExpectedMessage = "\nThe checked enumerable is null, where as it must have a first element.")]
+        public void HasFirstElementThrowsWhenCollectionIsNull()
+        {
+            var nullEnumerable = (List<int>)null;
+
+            // ReSharper disable once ExpressionIsAlwaysNull
+            Check.That(nullEnumerable).HasFirstElement();
+        }
+
+        #endregion
+
+        #region HasLastElement
+
+        [Test]
+        public void HasLastElementWorksForList()
+        {
+            var enumerable = new List<int> { 42, 43 };
+
+            Check.That(enumerable).HasLastElement().That.IsEqualTo(43);
+        }
+
+        [Test]
+        public void HasLastElementWorksForEnumerable()
+        {
+            var enumerable = new List<int> { 4, 3, 1, 2 }.OrderBy(x => x);
+
+            Check.That(enumerable).HasLastElement().That.IsEqualTo(4);
+        }
+
+        [Test]
+        [ExpectedException(typeof(FluentCheckException), ExpectedMessage = "\nThe checked enumerable is empty, where as it must have a last element.")]
+        public void HasLastElementThrowsWhenCollectionIsEmpty()
+        {
+            Check.That(EmptyEnumerable).HasLastElement();
+        }
+
+        [Test]
+        [ExpectedException(typeof(FluentCheckException), ExpectedMessage = "\nThe checked enumerable is null, where as it must have a last element.")]
+        public void HasLastElementThrowsWhenCollectionIsNull()
+        {
+            var nullEnumerable = (List<int>)null;
+
+            // ReSharper disable once ExpressionIsAlwaysNull
+            Check.That(nullEnumerable).HasLastElement();
+        }
+
+        #endregion
+
+        #region HasElementNumber
+
+        [Test]
+        public void HasElementNumberWorksForList()
+        {
+            var enumerable = new List<int> { 42, 43, 44 };
+
+            Check.That(enumerable).HasElementNumber(2).That.IsEqualTo(43);
+        }
+
+        [Test]
+        public void HasElementNumberWorksForEnumerable()
+        {
+            var enumerable = new List<int> { 4, 3, 1, 2 }.OrderBy(x => x);
+
+            Check.That(enumerable).HasElementNumber(3).That.IsEqualTo(3);
+        }
+
+        [Test]
+        [ExpectedException(typeof(FluentCheckException), ExpectedMessage = "\nThe checked enumerable has less that 1 elements, where as it must have an element with number 1.\nThe checked enumerable:\n\t[]")]
+        public void HasElementNumberThrowsWhenCollectionHasEnoughElementsIsEmpty()
+        {
+            Check.That(EmptyEnumerable).HasElementNumber(1);
+        }
+
+        [TestCase(-1)]
+        [TestCase(0)]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), ExpectedMessage = "The specified number is less than or equal to zero, where as it must be a 1-based index.\r\nParameter name: number")]
+        public void HasElementNumberThrowsWhenNumberIsInvalid(int number)
+        {
+            var enumerable = new List<int> { 42 };
+
+            Check.That(enumerable).HasElementNumber(number);
+        }
+
+        [Test]
+        [ExpectedException(typeof(FluentCheckException), ExpectedMessage = "\nThe checked enumerable is null, where as it must have an element with number 1.")]
+        public void HasElementNumberThrowsWhenCollectionIsNull()
+        {
+            var nullEnumerable = (List<int>)null;
+
+            // ReSharper disable once ExpressionIsAlwaysNull
+            Check.That(nullEnumerable).HasElementNumber(1);
+        }
+
+        [Test]
+        [ExpectedException(typeof(FluentCheckException), ExpectedMessage = "\nThe checked enumerable has less that 3 elements, where as it must have an element with number 3.\nThe checked enumerable:\n\t[42, 43]")]
+        public void HasElementNumberThrowsWhenCollectionHasNotEnoughElements()
+        {
+            var enumerable = new List<int> { 42, 43 };
+
+            Check.That(enumerable).HasElementNumber(3);
+        }
+
+        #endregion
+
+        #region HasOneElementOnly
+
+        [Test]
+        public void HasOneElementOnlyWorks()
+        {
+            var enumerable = new List<int> { 42 };
+
+            Check.That(enumerable).HasOneElementOnly().That.IsEqualTo(42);
+        }
+
+        [Test]
+        [ExpectedException(typeof(FluentCheckException), ExpectedMessage = "\nThe checked enumerable is empty, where as it must have one element.")]
+        public void HasOneElementOnlyThrowsWhenCollectionIsEmpty()
+        {
+            Check.That(EmptyEnumerable).HasOneElementOnly();
+        }
+
+        [Test]
+        [ExpectedException(typeof(FluentCheckException), ExpectedMessage = "\nThe checked enumerable is null, where as it must have one element.")]
+        public void HasOneElementOnlyThrowsWhenCollectionIsNull()
+        {
+            var nullEnumerable = (List<int>)null;
+
+            // ReSharper disable once ExpressionIsAlwaysNull
+            Check.That(nullEnumerable).HasOneElementOnly();
+        }
+
+        [Test]
+        [ExpectedException(typeof(FluentCheckException), ExpectedMessage = "\nThe checked enumerable contains more than one element, where as it must have one element only.\nThe checked enumerable:\n\t[42, 43, 1000]")]
+        public void HasOneElementOnlyThrowsWhenCollectionHasMoreThanOneElement()
+        {
+            var enumerable = new List<int> { 42, 43, 1000 };
+
+            Check.That(enumerable).HasOneElementOnly();
         }
 
         #endregion

--- a/NFluent.35/CollectionElementCheck.cs
+++ b/NFluent.35/CollectionElementCheck.cs
@@ -1,0 +1,34 @@
+﻿// // --------------------------------------------------------------------------------------------------------------------
+// // <copyright file="ICollectionElementCheck.cs" company="">
+// //   Copyright 2016 Thomas PIERRAIN
+// //   Licensed under the Apache License, Version 2.0 (the "License");
+// //   you may not use this file except in compliance with the License.
+// //   You may obtain a copy of the License at
+// //       http://www.apache.org/licenses/LICENSE-2.0
+// //   Unless required by applicable law or agreed to in writing, software
+// //   distributed under the License is distributed on an "AS IS" BASIS,
+// //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// //   See the License for the specific language governing permissions and
+// //   limitations under the License.
+// // </copyright>
+// // --------------------------------------------------------------------------------------------------------------------
+
+namespace NFluent
+{
+    /// <summary>
+    /// Provides a way to perform checks on collection elements.
+    /// </summary>
+    /// <typeparam name="T">Type of the collection elements.</typeparam>
+    internal class CollectionElementCheck<T> : ICollectionElementCheck<T>
+    {
+        public CollectionElementCheck(T element)
+        {
+            That = Check.That(element);
+        }
+
+        /// <summary>
+        /// Gets a <see cref="ICheck{T}"/> instance for the expected element.
+        /// </summary>
+        public ICheck<T> That { get; private set; }
+    }
+}

--- a/NFluent.35/ICollectionElementCheck.cs
+++ b/NFluent.35/ICollectionElementCheck.cs
@@ -1,0 +1,29 @@
+﻿// // --------------------------------------------------------------------------------------------------------------------
+// // <copyright file="ICollectionElementCheck.cs" company="">
+// //   Copyright 2016 Thomas PIERRAIN
+// //   Licensed under the Apache License, Version 2.0 (the "License");
+// //   you may not use this file except in compliance with the License.
+// //   You may obtain a copy of the License at
+// //       http://www.apache.org/licenses/LICENSE-2.0
+// //   Unless required by applicable law or agreed to in writing, software
+// //   distributed under the License is distributed on an "AS IS" BASIS,
+// //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// //   See the License for the specific language governing permissions and
+// //   limitations under the License.
+// // </copyright>
+// // --------------------------------------------------------------------------------------------------------------------
+
+namespace NFluent
+{
+    /// <summary>
+    /// Provides a way to perform checks on collection elements.
+    /// </summary>
+    /// <typeparam name="T">Type of the collection elements.</typeparam>
+    public interface ICollectionElementCheck<T>
+    {
+        /// <summary>
+        /// Gets a <see cref="ICheck{T}"/> instance for the expected element.
+        /// </summary>
+        ICheck<T> That { get; }
+    }
+}

--- a/NFluent.35/NFluent.35.csproj
+++ b/NFluent.35/NFluent.35.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Assertions\DoubleSpecificCheckExtensions.cs" />
     <Compile Include="Assertions\EventWaitHandleCheckExtensions.cs" />
     <Compile Include="Assertions\ObjectFieldsCheckExtensions.cs" />
+    <Compile Include="CollectionElementCheck.cs" />
     <Compile Include="Extensibility\EntityNamer.cs" />
     <Compile Include="Extensibility\EnumerationBlock.cs" />
     <Compile Include="Extensibility\GenericLabelBlock.cs" />
@@ -83,6 +84,7 @@
     <Compile Include="Helpers\ExceptionHelper.cs" />
     <Compile Include="Extensibility\FluentMessage.cs" />
     <Compile Include="ICodeCheck.cs" />
+    <Compile Include="ICollectionElementCheck.cs" />
     <Compile Include="IExposingChecker.cs" />
     <Compile Include="IHasParentCheck.cs" />
     <Compile Include="ILambdaExceptionCheck.cs" />

--- a/NFluent.40/NFluent.40.csproj
+++ b/NFluent.40/NFluent.40.csproj
@@ -134,6 +134,9 @@
     <Compile Include="..\NFluent.35\CheckLink.cs">
       <Link>CheckLink.cs</Link>
     </Compile>
+    <Compile Include="..\NFluent.35\CollectionElementCheck.cs">
+      <Link>CollectionElementCheck.cs</Link>
+    </Compile>
     <Compile Include="..\NFluent.35\Constants.cs">
       <Link>Constants.cs</Link>
     </Compile>
@@ -223,6 +226,9 @@
     </Compile>
     <Compile Include="..\NFluent.35\ICodeCheck.cs">
       <Link>ICodeCheck.cs</Link>
+    </Compile>
+    <Compile Include="..\NFluent.35\ICollectionElementCheck.cs">
+      <Link>ICollectionElementCheck.cs</Link>
     </Compile>
     <Compile Include="..\NFluent.35\IExposingChecker.cs">
       <Link>IExposingChecker.cs</Link>

--- a/NFluent.PCL/NFluent.PCL.csproj
+++ b/NFluent.PCL/NFluent.PCL.csproj
@@ -139,6 +139,9 @@
     <Compile Include="..\NFluent.35\CheckLink.cs">
       <Link>CheckLink.cs</Link>
     </Compile>
+    <Compile Include="..\NFluent.35\CollectionElementCheck.cs">
+      <Link>CollectionElementCheck.cs</Link>
+    </Compile>
     <Compile Include="..\NFluent.35\Constants.cs">
       <Link>Constants.cs</Link>
     </Compile>
@@ -228,6 +231,9 @@
     </Compile>
     <Compile Include="..\NFluent.35\ICodeCheck.cs">
       <Link>ICodeCheck.cs</Link>
+    </Compile>
+    <Compile Include="..\NFluent.35\ICollectionElementCheck.cs">
+      <Link>ICollectionElementCheck.cs</Link>
     </Compile>
     <Compile Include="..\NFluent.35\IExposingChecker.cs">
       <Link>IExposingChecker.cs</Link>


### PR DESCRIPTION
I regularly need to check properties on the first or single element of a collection.
It is easy to write:

``` cs
Check.That(enumerable.First()).IsEqualTo(42);
```

Yet I would like the exception to be generated from an assertion and not from the `First` method.
My tests can use custom `ExpectedFirst` and `ExpectedSingle` methods but those do not really follow the NFluent philosophy.

So I propose to add extension methods for collection checks that could be used in the following way:

``` cs
Check.That(enumerable).First().IsEqualTo(42);
```
