### PR TITLE
Use minimal version NETStandard 1.3 to be more compatible

### DIFF
--- a/NFluent.Core/project.json
+++ b/NFluent.Core/project.json
@@ -1,13 +1,20 @@
 {
   "version": "1.0.0-*",
-    "dependencies": {
-        "NETStandard.Library": "1.6.0",
-        "System.Diagnostics.Process": "4.1.0",
-        "System.Reflection.TypeExtensions": "4.1.0",
-        "System.Runtime.Extensions": "4.1.0"
-    },
+  "dependencies": {
+    "System.Collections": "4.3.0",
+    "System.Diagnostics.Debug": "4.3.0",
+    "System.Diagnostics.Process": "4.3.0",
+    "System.Diagnostics.Tools": "4.3.0",
+    "System.Globalization": "4.3.0",
+    "System.IO.FileSystem": "4.3.0",
+    "System.Linq": "4.3.0",
+    "System.Reflection.TypeExtensions": "4.3.0",
+    "System.Runtime.Extensions": "4.3.0",
+    "System.Text.RegularExpressions": "4.3.0",
+    "System.Threading": "4.3.0"
+  },
     "frameworks": {
-        "netstandard1.6": {
+        "netstandard1.3": {
             "imports": "dnxcore50"
         }
     },

--- a/NFluent.Tests.Extensions.Core/project.json
+++ b/NFluent.Tests.Extensions.Core/project.json
@@ -1,14 +1,14 @@
 {
   "version": "1.0.0-*",
 
-    "dependencies": {
-        "NETStandard.Library": "1.6.0",
-        "NFluent.Core": "1.0.0-*",
-        "NUnit": "3.4.1"
-    },
+  "dependencies": {
+    "System.Runtime.InteropServices": "4.3.0",
+    "NFluent.Core": { "target": "project" },
+    "NUnit": "3.4.1"
+  },
 
   "frameworks": {
-    "netstandard1.6": {
+    "netstandard1.3": {
       "imports": "dnxcore50"
     }
   }

--- a/NFluent.nuspec
+++ b/NFluent.nuspec
@@ -56,7 +56,7 @@
     <file src="Artifacts\Binaries\PCL\NFluent.dll" target="lib\portable-net45+sl5+netcore45+MonoAndroid1+MonoTouch1\NFluent.dll" />
     <file src="Artifacts\Binaries\PCL\NFluent.xml" target="lib\portable-net45+sl5+netcore45+MonoAndroid1+MonoTouch1\NFluent.xml" />
     <!-- Core -->
-    <file src="Artifacts\Binaries\Core\netstandard1.6\NFluent.Core.dll" target="lib\netstandard1.6\NFluent.Core.dll" />
-    <file src="Artifacts\Binaries\Core\netstandard1.6\NFluent.Core.pdb" target="lib\netstandard1.6\NFluent.Core.pdb" />
+    <file src="Artifacts\Binaries\Core\netstandard1.3\NFluent.Core.dll" target="lib\netstandard1.3\NFluent.Core.dll" />
+    <file src="Artifacts\Binaries\Core\netstandard1.3\NFluent.Core.pdb" target="lib\netstandard1.3\NFluent.Core.pdb" />
   </files>
 </package>


### PR DESCRIPTION
I've changed `NETStandard1.6` to `NETStandard1.3` to be better compatible.

Note that a lower dependency is always better.