### PR TITLE
ContainsOnlyElementsThatMatch for enumables

### DIFF
--- a/src/NFluent/Checks/EnumerableCheckExtensions.cs
+++ b/src/NFluent/Checks/EnumerableCheckExtensions.cs
@@ -476,7 +476,7 @@ namespace NFluent
         /// <param name="check">Check item.</param>
         /// <param name="predicate">Predicate to evaluate.</param>
         /// <returns>A linkable check.</returns>
-        public static ICheckLinkWhich<ICheck<IEnumerable<T>>, ICheck<T>> HasAllElementsThatMatch<T>(
+        public static ICheckLinkWhich<ICheck<IEnumerable<T>>, ICheck<T>> ContainsOnlyElementsThatMatch<T>(
             this ICheck<IEnumerable<T>> check,
             Func<T, bool> predicate)
         {
@@ -504,7 +504,7 @@ namespace NFluent
                         return itemCheck;
                     }
                 },
-                checker.BuildMessage("The {0} contains all element(s) that match the given predicate, whereas it must not.").ToString());
+                checker.BuildMessage("The {0} contains only element(s) that match the given predicate, whereas it must not.").ToString());
         }
 
         /// <summary> 

--- a/src/NFluent/Checks/EnumerableCheckExtensions.cs
+++ b/src/NFluent/Checks/EnumerableCheckExtensions.cs
@@ -469,6 +469,44 @@ namespace NFluent
             checker.BuildMessage("The {0} contains element(s) that matches the given predicate, whereas it must not.").ToString());
         }
 
+        /// <summary>
+        /// Checks that the given enumerable does contain all items matching a predicate.
+        /// </summary>
+        /// <typeparam name="T">Type of items.</typeparam>
+        /// <param name="check">Check item.</param>
+        /// <param name="predicate">Predicate to evaluate.</param>
+        /// <returns>A linkable check.</returns>
+        public static ICheckLinkWhich<ICheck<IEnumerable<T>>, ICheck<T>> HasAllElementsThatMatch<T>(
+            this ICheck<IEnumerable<T>> check,
+            Func<T, bool> predicate)
+        {
+            var checker = ExtensibilityHelper.ExtractChecker(check);
+            return checker.ExecuteCheckAndProvideSubItem(
+                () =>
+                {
+                    using (var scan = checker.Value.GetEnumerator())
+                    {
+                     
+                        while (scan.MoveNext())
+                        {
+                            if (!predicate(scan.Current))
+                            {
+                                var message =
+                                    checker.BuildMessage(
+                                        "The {0} does contain an element that does not match the given predicate.");
+                                throw new FluentCheckException(message.ToString());
+                            }
+                        }
+
+                        var itemCheck = Check.That(scan.Current);
+                        var subChecker = ExtensibilityHelper.ExtractChecker(itemCheck);
+                        subChecker.SetSutLabel($"all elements");
+                        return itemCheck;
+                    }
+                },
+                checker.BuildMessage("The {0} contains all element(s) that match the given predicate, whereas it must not.").ToString());
+        }
+
         /// <summary> 
         /// Checks that the enumerable has a first element, and returns a check on that element. 
         /// </summary> 

--- a/tests/NFluent.Tests/EnumerableRelatedTests.cs
+++ b/tests/NFluent.Tests/EnumerableRelatedTests.cs
@@ -264,10 +264,10 @@ namespace NFluent.Tests
             var enumerable = new List<int> { 42, 43 };
             Check.That(enumerable).HasFirstElement().Which.IsEqualTo(42);
         }
-       [Test]
+        [Test]
         public void NotHasFirstElementWorks()
         {
-            var enumerable = new List<int> {};
+            var enumerable = new List<int> { };
             Check.That(enumerable).Not.HasFirstElement();
         }
 
@@ -277,7 +277,7 @@ namespace NFluent.Tests
             Check.ThatCode(() =>
             Check.That(EmptyEnumerable).HasFirstElement())
             .Throws<FluentCheckException>().AndWhichMessage().AsLines().ContainsExactly(
-                "", 
+                "",
                 "The checked enumerable is empty, whereas it must have a first element.");
         }
 
@@ -305,14 +305,14 @@ namespace NFluent.Tests
         [Test]
         public void NotHasLastElementWorks()
         {
-            var enumerable = new List<int> {};
+            var enumerable = new List<int> { };
             Check.That(enumerable).Not.HasLastElement();
         }
 
         [Test]
         public void NotHasLastElementWorksForNonList()
         {
-            var enumerable = (new List<int> {}).Where((_) => true);
+            var enumerable = (new List<int> { }).Where((_) => true);
             Check.That(enumerable).Not.HasLastElement();
         }
 
@@ -327,10 +327,10 @@ namespace NFluent.Tests
         [Test]
         public void HasLastElementThrowsWhenCollectionIsEmpty()
         {
-            Check.ThatCode( ()=>
-            Check.That(EmptyEnumerable).HasLastElement())
+            Check.ThatCode(() =>
+           Check.That(EmptyEnumerable).HasLastElement())
                 .Throws<FluentCheckException>().AndWhichMessage().AsLines().ContainsExactly(
-                "", 
+                "",
                 "The checked enumerable is empty, whereas it must have a last element.");
         }
 
@@ -345,6 +345,8 @@ namespace NFluent.Tests
         }
 
         #endregion
+
+
 
         #region HasElementNumber
 
@@ -379,7 +381,7 @@ namespace NFluent.Tests
                     Check.That(EmptyEnumerable).HasElementAt(0))
                 .Throws<FluentCheckException>().AndWhichMessage().AsLines().ContainsExactly(
                 "",
-                "The checked enumerable does not have an element at index 0.", 
+                "The checked enumerable does not have an element at index 0.",
                 "The checked enumerable:",
                 "\t[]");
         }
@@ -431,7 +433,7 @@ namespace NFluent.Tests
         [Test]
         public void NotHasOneElementOnlyWorks()
         {
-            var enumerable = new List<int> {};
+            var enumerable = new List<int> { };
             Check.That(enumerable).Not.HasOneElementOnly();
         }
 
@@ -470,6 +472,34 @@ namespace NFluent.Tests
                     "The checked enumerable:",
                     "\t[42, 43, 1000]");
 
+        }
+
+        #endregion
+
+        #region HasAllElements
+
+        [Test]
+        public void HasAllElementShouldNotFailIfCheckIsEmpty()
+        {
+            IEnumerable<string> emptyList = new List<string> { };
+            Check.ThatCode(() => Check.That(emptyList).HasAllElementsThatMatch(item => true))
+                .DoesNotThrow();
+        }
+
+        [Test]
+        public void HasAllElementShouldNotFailIfAllElementMatch()
+        {
+            IEnumerable<int> list = new List<int> {4,6,8 };
+            Check.ThatCode(() => Check.That(list).HasAllElementsThatMatch(item => item % 2 == 0))
+                .DoesNotThrow();
+        }
+
+        [Test]
+        public void HasAllElementShouldFailIfAnElementDoesNotMatch()
+        {
+            IEnumerable<int> list = new List<int> { 4, 5, 8 };
+            Check.ThatCode(() => Check.That(list).HasAllElementsThatMatch(item => item % 2 == 0))
+                .Throws<FluentCheckException>();
         }
 
         #endregion

--- a/tests/NFluent.Tests/EnumerableRelatedTests.cs
+++ b/tests/NFluent.Tests/EnumerableRelatedTests.cs
@@ -476,29 +476,29 @@ namespace NFluent.Tests
 
         #endregion
 
-        #region HasAllElements
+        #region ContainsOnlyElement
 
         [Test]
-        public void HasAllElementShouldNotFailIfCheckIsEmpty()
+        public void ContainsOnlyElementShouldNotFailIfCheckIsEmpty()
         {
             IEnumerable<string> emptyList = new List<string> { };
-            Check.ThatCode(() => Check.That(emptyList).HasAllElementsThatMatch(item => true))
+            Check.ThatCode(() => Check.That(emptyList).ContainsOnlyElementsThatMatch(item => true))
                 .DoesNotThrow();
         }
 
         [Test]
-        public void HasAllElementShouldNotFailIfAllElementMatch()
+        public void ContainsOnlyElementShouldNotFailIfAllElementMatch()
         {
             IEnumerable<int> list = new List<int> {4,6,8 };
-            Check.ThatCode(() => Check.That(list).HasAllElementsThatMatch(item => item % 2 == 0))
+            Check.ThatCode(() => Check.That(list).ContainsOnlyElementsThatMatch(item => item % 2 == 0))
                 .DoesNotThrow();
         }
 
         [Test]
-        public void HasAllElementShouldFailIfAnElementDoesNotMatch()
+        public void ContainsOnlyElementShouldFailIfAnElementDoesNotMatch()
         {
             IEnumerable<int> list = new List<int> { 4, 5, 8 };
-            Check.ThatCode(() => Check.That(list).HasAllElementsThatMatch(item => item % 2 == 0))
+            Check.ThatCode(() => Check.That(list).ContainsOnlyElementsThatMatch(item => item % 2 == 0))
                 .Throws<FluentCheckException>();
         }
 


### PR DESCRIPTION
The method HasAllElementsThatMatch checks if all elements of an Ienumerable are validated by the same predicate. This is the almost the same as "Not.HasElementThatMatches(!predicate)" but much clearer. The difference is that if the enumeration is empty the check passes.