### PR TITLE
Avoid to call async lambda twice

### DIFF
--- a/src/NFluent/Kernel/FluentCodeCheck.cs
+++ b/src/NFluent/Kernel/FluentCodeCheck.cs
@@ -215,8 +215,7 @@ namespace NFluent.Kernel
                         try
                         {
                             // starts and waits the completion of the awaitable method
-                            waitableFunction().Wait();
-                            result.Result = waitableFunction().Result;
+                            result.Result = waitableFunction.Result;
                         }
                         catch (AggregateException agex)
                         {

--- a/src/NFluent/Kernel/FluentCodeCheck.cs
+++ b/src/NFluent/Kernel/FluentCodeCheck.cs
@@ -215,7 +215,7 @@ namespace NFluent.Kernel
                         try
                         {
                             // starts and waits the completion of the awaitable method
-                            result.Result = waitableFunction.Result;
+                            result.Result = waitableFunction().Result;
                         }
                         catch (AggregateException agex)
                         {


### PR DESCRIPTION
When passing async lambda like ``Check.ThatAsyncCode(async () => await MyMethod())`` the lambda was called *twice*. This implicitly assumes all lambdas must idempotent in their behaviour.

-> Fixed:  only call async lambda once.