### PR TITLE
Add Extracting method with lambda to get properties

### DIFF
--- a/src/NFluent/Helpers/Polyfill.cs
+++ b/src/NFluent/Helpers/Polyfill.cs
@@ -228,6 +228,15 @@ namespace NFluent
             }
             return false;
         }
+    
+        public static IEnumerable<TR> Select<T, TR>(this IEnumerable<T> list, Func<T, TR> selector) {
+            var result = new List<TR>();
+            foreach (var item in list)
+            {
+                result.Add(selector.Invoke(item));
+            }
+            return result;
+        } 
 #endif
         public static bool IsNullOrWhiteSpace(string texte)
         {

--- a/src/NFluent/Kernel/ExtractingExtensions.cs
+++ b/src/NFluent/Kernel/ExtractingExtensions.cs
@@ -19,7 +19,8 @@ namespace NFluent
     using System.Collections;
     using System.Collections.Generic;
     using System.Reflection;
-#if !DOTNET_35 && !DOTNET_20 && !DOTNET_30
+    using Extensibility;
+#if !DOTNET_30 && !DOTNET_20
     using System.Linq;
 #endif
 
@@ -102,7 +103,6 @@ namespace NFluent
             return Extracting(array, propertyName);
         }
 
-#if !DOTNET_35 && !DOTNET_20 && !DOTNET_30
         /// <summary>
         /// Extract all the values of a given property given its getter lambda, from an enumerable collection of objects holding that property.
         /// </summary>
@@ -133,6 +133,5 @@ namespace NFluent
             var enumerableArray = array as IEnumerable<T>;
             return enumerableArray.Extracting(getter);
         }
-#endif
     }
 }

--- a/src/NFluent/Kernel/ExtractingExtensions.cs
+++ b/src/NFluent/Kernel/ExtractingExtensions.cs
@@ -19,6 +19,9 @@ namespace NFluent
     using System.Collections;
     using System.Collections.Generic;
     using System.Reflection;
+#if !DOTNET_35 && !DOTNET_20 && !DOTNET_30
+    using System.Linq;
+#endif
 
     /// <summary>
     /// Extension methods for exploiting enumerable content in a fluent manner (i.e. with auto completion support and in an english readable way).
@@ -98,5 +101,38 @@ namespace NFluent
         {
             return Extracting(array, propertyName);
         }
+
+#if !DOTNET_35 && !DOTNET_20 && !DOTNET_30
+        /// <summary>
+        /// Extract all the values of a given property given its getter lambda, from an enumerable collection of objects holding that property.
+        /// </summary>
+        /// <param name="enumerable">The enumerable collection of objects.</param>
+        /// <param name="getter">Lambda to extract value of the property from for every object of the collection.</param>
+        /// <typeparam name="T">Type of the objects belonging to the initial enumerable collection.</typeparam>
+        /// <typeparam name="TP">Type of the extracted values.</typeparam>
+        /// <returns>
+        /// An enumerable of all the property values typed <typeparamref name="TP"/> for every <typeparamref name="T"/> objects in the <paramref name="enumerable"/>.
+        /// </returns>
+        public static IEnumerable<TP> Extracting<T, TP>(this IEnumerable<T> enumerable, Func<T, TP> getter)
+        {
+            return enumerable.Select(getter.Invoke);
+        }
+        
+        /// <summary>
+        /// Extract all the values of a given property given its getter lambda, from an enumerable collection of objects holding that property.
+        /// </summary>
+        /// <param name="array">The array of <typeparamref name="T"/>.</param>
+        /// <param name="getter">Lambda to extract value of the property from for every object of the collection.</param>
+        /// <typeparam name="T">Type of the objects belonging to the initial enumerable collection.</typeparam>
+        /// <typeparam name="TP">Type of the extracted values.</typeparam>
+        /// <returns>
+        /// An enumerable of all the property values typed <typeparamref name="TP"/> for every <typeparamref name="T"/> objects in the <see cref="Array"/>.
+        /// </returns>
+        public static IEnumerable<TP> Extracting<T, TP>(this T[] array, Func<T, TP> getter)
+        {
+            var enumerableArray = array as IEnumerable<T>;
+            return enumerableArray.Extracting(getter);
+        }
+#endif
     }
 }

--- a/tests/NFluent.Tests/ExtractingRelatedTests.cs
+++ b/tests/NFluent.Tests/ExtractingRelatedTests.cs
@@ -48,7 +48,6 @@ namespace NFluent.Tests
             // assertThat(inn.getItems()).onProperty("name").containsExactly("+5 Dexterity Vest", "Aged Brie", "Elixir of the Mongoose", "Sulfuras, Hand of Ragnaros", "Backstage passes to a TAFKAL80ETC concert", "Conjured Mana Cake");
         }
 
-#if !DOTNET_35 && !DOTNET_20 && !DOTNET_30
         [Test]
         public void LambdaExtractingWorksWithEnumerable()
         {
@@ -64,7 +63,6 @@ namespace NFluent.Tests
             Check.That(persons.Extracting(p => p.Age)).ContainsExactly(38, 10, 7, 7);
             Check.That(persons.Extracting(p => p.Nationality)).ContainsExactly(Nationality.Unknown, Nationality.French, Nationality.French, Nationality.Indian);
         }
-#endif
 
         [Test]
         public void ExtractingThrowInvalidOperationExceptionIfPropertyDoesNotExist()
@@ -117,7 +115,6 @@ namespace NFluent.Tests
             Check.That(persons.Extracting("Nationality")).ContainsExactly(Nationality.Unknown, Nationality.French, Nationality.French, Nationality.Indian);
         }
 
-#if !DOTNET_35 && !DOTNET_20 && !DOTNET_30
         [Test]
         public void LambdaExtractingWorksWithArray()
         {
@@ -133,7 +130,6 @@ namespace NFluent.Tests
             Check.That(persons.Extracting(p => p.Age)).ContainsExactly(38, 10, 7, 7);
             Check.That(persons.Extracting(p => p.Nationality)).ContainsExactly(Nationality.Unknown, Nationality.French, Nationality.French, Nationality.Indian);
         }
-#endif
 
 #pragma warning disable 618
         [Test]

--- a/tests/NFluent.Tests/ExtractingRelatedTests.cs
+++ b/tests/NFluent.Tests/ExtractingRelatedTests.cs
@@ -16,7 +16,6 @@ namespace NFluent.Tests
 {
     using System;
     using System.Collections.Generic;
-
     using NUnit.Framework;
 
     [TestFixture]
@@ -48,6 +47,24 @@ namespace NFluent.Tests
             // FEST fluent assert v 1.x:
             // assertThat(inn.getItems()).onProperty("name").containsExactly("+5 Dexterity Vest", "Aged Brie", "Elixir of the Mongoose", "Sulfuras, Hand of Ragnaros", "Backstage passes to a TAFKAL80ETC concert", "Conjured Mana Cake");
         }
+
+#if !DOTNET_35 && !DOTNET_20 && !DOTNET_30
+        [Test]
+        public void LambdaExtractingWorksWithEnumerable()
+        {
+            var persons = new List<Person>
+            {
+                new Person {Name = "Thomas", Age = 38},
+                new Person {Name = "Achille", Age = 10, Nationality = Nationality.French},
+                new Person {Name = "Anton", Age = 7, Nationality = Nationality.French},
+                new Person {Name = "Arjun", Age = 7, Nationality = Nationality.Indian}
+            };
+
+            Check.That(persons.Extracting(p => p.Name)).ContainsExactly("Thomas", "Achille", "Anton", "Arjun");
+            Check.That(persons.Extracting(p => p.Age)).ContainsExactly(38, 10, 7, 7);
+            Check.That(persons.Extracting(p => p.Nationality)).ContainsExactly(Nationality.Unknown, Nationality.French, Nationality.French, Nationality.Indian);
+        }
+#endif
 
         [Test]
         public void ExtractingThrowInvalidOperationExceptionIfPropertyDoesNotExist()
@@ -99,6 +116,24 @@ namespace NFluent.Tests
             Check.That(persons.Extracting("Age")).ContainsExactly(38, 10, 7, 7);
             Check.That(persons.Extracting("Nationality")).ContainsExactly(Nationality.Unknown, Nationality.French, Nationality.French, Nationality.Indian);
         }
+
+#if !DOTNET_35 && !DOTNET_20 && !DOTNET_30
+        [Test]
+        public void LambdaExtractingWorksWithArray()
+        {
+            Person[] persons = new[]
+            {
+                new Person {Name = "Thomas", Age = 38},
+                new Person {Name = "Achille", Age = 10, Nationality = Nationality.French},
+                new Person {Name = "Anton", Age = 7, Nationality = Nationality.French},
+                new Person {Name = "Arjun", Age = 7, Nationality = Nationality.Indian}
+            };
+
+            Check.That(persons.Extracting(p => p.Name)).ContainsExactly("Thomas", "Achille", "Anton", "Arjun");
+            Check.That(persons.Extracting(p => p.Age)).ContainsExactly(38, 10, 7, 7);
+            Check.That(persons.Extracting(p => p.Nationality)).ContainsExactly(Nationality.Unknown, Nationality.French, Nationality.French, Nationality.Indian);
+        }
+#endif
 
 #pragma warning disable 618
         [Test]


### PR DESCRIPTION
Currently we use `Extracting` method with **property name**.
But it might bring a bug from mistyped property name.
```csharp
Check.That(persons.Extracting("Age")).ContainsExactly(38, 10, 7, 7);   
```

With property getter lambda, it can be naturally prevented in compile time and even more concise way.
```csharp
Check.That(persons.Extracting(p => p.Age)).ContainsExactly(38, 10, 7, 7);  
```

With .net framework under version 3.5, it is not supported due to linq.