### PR TITLE
Make IsInDescendingOrder working like IsInAscendingOrder

### DIFF
--- a/code/src/NFluent/Checks/EnumerableCheckExtensions.cs
+++ b/code/src/NFluent/Checks/EnumerableCheckExtensions.cs
@@ -1025,10 +1025,10 @@ namespace NFluent
                 FailIfNull().
                 Analyze((sut, test) =>
                 {
-                    IComparable previous = null;
+                    object previous = null;
                     var index = 0;
                     var first = true;
-                    foreach (IComparable current in sut)
+                    foreach (var current in sut)
                     {
                         if (!first)
                         {


### PR DESCRIPTION
No need to inherit from IComparable.

![image](https://user-images.githubusercontent.com/13761085/73358820-c0cb3e80-429f-11ea-9d99-4acd78b42c1b.png)
