### PR TITLE
fix: DifferenceFinders against empty collection

### DIFF
--- a/code/src/NFluent/Helpers/DifferenceFinders.cs
+++ b/code/src/NFluent/Helpers/DifferenceFinders.cs
@@ -370,7 +370,7 @@ namespace NFluent.Helpers
                 if (!scanner.MoveNext())
                 {
                     valueDifferences.Add(DifferenceDetails.WasNotExpected(firstItemName, actualItem, index));
-                    unexpected.Add(index, actualItem);
+                    unexpected.Add(index++, actualItem);
                     if (options.HasFlag(Option.Fast))
                     {
                         return DifferenceDetails.DoesNotHaveExpectedValue(firstName, actualEnumerable, expectedEnumerable, sutIndex, expectedIndex);

--- a/code/tests/NFluent.Tests/EnumerableCheckShould.cs
+++ b/code/tests/NFluent.Tests/EnumerableCheckShould.cs
@@ -300,7 +300,23 @@ namespace NFluent.Tests
                     "The expected enumerable:", 
                     "\t{{3,3,1},{4,5,6}} (2 items)");
         }
-        
+
+        [Test]
+        public void CheckIsEquivalentMoreThanOneExtra()
+        {
+            var actual = new[] { 1, 2 };
+            var expected = Enumerable.Repeat(0, 0);
+            Check.ThatCode(() =>  Check.That((IEnumerable)actual).IsEquivalentTo(expected))
+                .IsAFailingCheckWithMessage("",
+                    "The checked enumerable is not equivalent to the expected one. 2 differences found!",
+                    "actual[0] value should not exist (value 1)",
+                    "actual[1] value should not exist (value 2)",
+                    "The checked enumerable:",
+                    "\t{1,2} (2 items)",
+                    "The expected enumerable:",
+                    "\t{} (0 item)");
+        }
+
         [Test]
         public void CheckIsEqualWorksOnSet()
         {


### PR DESCRIPTION
Currently e.g.:

    Check.That(Enumerable.Repeat(1, 2)).IsEquivalentTo(Enumerable.Repeat(0, 0))

Would blow up with:

    System.ArgumentException : An item with the same key has already been added. Key: 1
    Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
    Dictionary`2.Add(TKey key, TValue value)
    DifferenceFinders.ScanEnumeration(IEnumerable actualEnumerable, IEnumerable expectedEnumerable, String firstName, Func`2 namingCallback, Int64 sutIndex, Int64 expectedIndex, IDictionary`2 firstSeen, Option options)
